### PR TITLE
fix broken =F mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ e.g. on cljfmt.
 ## Features
 
 - Code formatting (uses [cljfmt][cljfmt])
-  - `cff` (current form), `cf{motion}`, `cF` (current file)
+  - `=ff` (current form), `=f{motion}`, `=F` (current file)
 - Var undef / alias unmap
   - `cdd`
 - Clean ns (eliminate `:use`, sort, remove unused stuff and duplication)

--- a/plugin/cider.vim
+++ b/plugin/cider.vim
@@ -238,7 +238,7 @@ function! s:set_up() abort
 
   nmap <buffer> =f <Plug>CiderFormat
   nmap <buffer> =ff <Plug>CiderCountFormat
-  nmap <buffer> =F ggcfG
+  nmap <buffer> =F gg=fG
 
   nmap <buffer> cdd <Plug>CiderUndef
   nmap <buffer> <F4> <Plug>RefactorCleanNs


### PR DESCRIPTION
When the mapping was changed from 'cf', 'cff', and 'cF' to use the '='
leader character, the '=F' mapping was broken as it still attempted to
use the 'cf' mapping.

The docs have been updated to reflect this change aswell.