### PR TITLE
fix refactor-nrepl option passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ own. Check the implementation file for `<Plug>` bindings.
 ```vim
 let g:cider_no_maps=1 " Disable built-in mappings
 
-" Set refactor-nrepl options, e.g. tell clean-ns to not use prefix forms
-let g:refactor_nrepl_options = '{:prefix-rewriting false}'
+" Set refactor-nrepl options 
+let g:refactor_nrepl_prefix_rewriting = 0  " tell clean-ns to not use prefix forms
+let g:refactor_nrepl_prune_ns_form = 0     " ... and don't remove unused symbols
 
 " Setup visualmode bindings yourself, to some keys which don't interact
 " with e.g. change command

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ own. Check the implementation file for `<Plug>` bindings.
 let g:cider_no_maps=1 " Disable built-in mappings
 
 " Set refactor-nrepl options 
-let g:refactor_nrepl_prefix_rewriting = 0  " tell clean-ns to not use prefix forms
-let g:refactor_nrepl_prune_ns_form = 0     " ... and don't remove unused symbols
+let g:refactor_nrepl_options = {
+	\ 'prefix-rewriting': 'false',      " tell clean-ns to not use prefix forms
+	\ 'prune-ns-form': 'false',         " ... and don't remove unused symbols
+	\ }
 
 " Setup visualmode bindings yourself, to some keys which don't interact
 " with e.g. change command

--- a/doc/cider.txt
+++ b/doc/cider.txt
@@ -16,18 +16,10 @@ DOCUMENTATION                                   *cider-documentation*
                                                 *cider-no-maps*
 g:cider_no_maps         Set this option to true to disable built-in maps.
 
-                                                *refactor-nrepl-prune-ns-form*
-g:refactor_nrepl_prune_ns_form
-                        Use this option to set the prune-ns-form option for
-						refactor-nrepl. Check
-						https://github.com/clojure-emacs/refactor-nrepl#configure
-                        for documentation.
-
-                                                *refactor-nrepl-prefix-rewriting*
-g:refactor_nrepl_prefix_rewriting
-                        Use this option to set the prefix-rewriting option for
-						refactor-nrepl. Check
-						https://github.com/clojure-emacs/refactor-nrepl#configure
+                                                *refactor-nrepl-options*
+g:refactor_nrepl_options
+						Use this option to set settings for refactor-nrepl.
+						Check https://github.com/clojure-emacs/refactor-nrepl#configure
                         for documentation.
 
                                                 *cider-=f*

--- a/doc/cider.txt
+++ b/doc/cider.txt
@@ -16,14 +16,22 @@ DOCUMENTATION                                   *cider-documentation*
                                                 *cider-no-maps*
 g:cider_no_maps         Set this option to true to disable built-in maps.
 
-                                                *refactor-nrepl-options*
-g:refactor_nrepl_options
-                        Use this option to set settings for refactor-nrepl.
-                        Check https://github.com/clojure-emacs/refactor-nrepl#configure
+                                                *refactor-nrepl-prune-ns-form*
+g:refactor_nrepl_prune_ns_form
+                        Use this option to set the prune-ns-form option for
+						refactor-nrepl. Check
+						https://github.com/clojure-emacs/refactor-nrepl#configure
                         for documentation.
 
-                                                *cider-cf*
-cf{motion}              Format the code indicated by {motion}.
+                                                *refactor-nrepl-prefix-rewriting*
+g:refactor_nrepl_prefix_rewriting
+                        Use this option to set the prefix-rewriting option for
+						refactor-nrepl. Check
+						https://github.com/clojure-emacs/refactor-nrepl#configure
+                        for documentation.
+
+                                                *cider-=f*
+=f{motion}              Format the code indicated by {motion}.
                         Use <Plug>CiderFormat to map this yourself.
                         Visual mode mapping is not by default enabled but you
                         can do that yourself:
@@ -33,15 +41,15 @@ cf{motion}              Format the code indicated by {motion}.
                         Just remeber to use mapping which doesn't conflict
                         with e.g. change command.
 
-                                                *cider-cff*
-cff                     Format the innertmost form at the cursor.
+                                                *cider-=ff*
+=ff                     Format the innertmost form at the cursor.
                         Like |fireplace-c!|
                         Use <Plug>CiderFormatCount to map this yourself.
 
-                                                *cider-cF*
-cF                      Format the current file.
-                        Use ggcfG to map this yourself (notice to use your own
-                        |cider-cf| mapping.)
+                                                *cider-=F*
+=F                      Format the current file.
+                        Use gg=fG to map this yourself (notice to use your own
+                        |cider-=f| mapping.)
 
                                                 *cider-cdd*
 cdd                     Undefine a variable or unalias namespace a alias

--- a/plugin/cider.vim
+++ b/plugin/cider.vim
@@ -111,13 +111,6 @@ nnoremap <silent> <Plug>CiderUndef :<C-U>call <SID>undef()<CR>
 " CleanNs
 "
 
-function! s:init_refactor_nrepl() abort
-  if !exists('b:refactor_nrepl_loaded') && exists('g:refactor_nrepl_options')
-    let b:refactor_nrepl_loaded = 1
-    call fireplace#message({'op': 'configure', 'opts': g:refactor_nrepl_options})
-  endif
-endfunction
-
 function! s:paste(text) abort
   " Does charwise paste to current '[ and '] marks
   let @@ = a:text
@@ -128,8 +121,6 @@ function! s:paste(text) abort
 endfunction
 
 function! s:clean_ns() abort
-  call s:init_refactor_nrepl()
-
   " FIXME: Moves cursor
 
   let p = expand('%:p')
@@ -145,7 +136,17 @@ function! s:clean_ns() abort
   call setpos("']", [0, line2, col2, 0])
 
   if expand('<cword>') ==? 'ns'
-    let res = fireplace#message({'op': 'clean-ns', 'path': p})[0]
+	let opts = { 'op': 'clean-ns', 'path': p }
+
+	if exists('g:refactor_nrepl_prune_ns_form')
+		let opts['prune-ns-form'] = g:refactor_nrepl_prune_ns_form ? 'true' : 'false'
+	endif
+
+	if exists('g:refactor_nrepl_prefix_rewriting')
+		let opts['prefix-rewriting'] = g:refactor_nrepl_prefix_rewriting ? 'true' : 'false'
+	endif
+
+	let res = fireplace#message(opts)[0]
     let error = get(res, 'error')
     if !empty(error)
       throw error

--- a/plugin/cider.vim
+++ b/plugin/cider.vim
@@ -138,12 +138,10 @@ function! s:clean_ns() abort
   if expand('<cword>') ==? 'ns'
 	let opts = { 'op': 'clean-ns', 'path': p }
 
-	if exists('g:refactor_nrepl_prune_ns_form')
-		let opts['prune-ns-form'] = g:refactor_nrepl_prune_ns_form ? 'true' : 'false'
-	endif
-
-	if exists('g:refactor_nrepl_prefix_rewriting')
-		let opts['prefix-rewriting'] = g:refactor_nrepl_prefix_rewriting ? 'true' : 'false'
+	if exists('g:refactor_nrepl_options')
+		for [opt_k, opt_v] in items(g:refactor_nrepl_options)
+			let opts[opt_k] = opt_v
+		endfor
 	endif
 
 	let res = fireplace#message(opts)[0]

--- a/plugin/cider.vim
+++ b/plugin/cider.vim
@@ -136,15 +136,10 @@ function! s:clean_ns() abort
   call setpos("']", [0, line2, col2, 0])
 
   if expand('<cword>') ==? 'ns'
-	let opts = { 'op': 'clean-ns', 'path': p }
+    let opts = { 'op': 'clean-ns', 'path': p }
+    call extend(opts, get(g:, 'refactor_nrepl_options', {}))
 
-	if exists('g:refactor_nrepl_options')
-		for [opt_k, opt_v] in items(g:refactor_nrepl_options)
-			let opts[opt_k] = opt_v
-		endfor
-	endif
-
-	let res = fireplace#message(opts)[0]
+    let res = fireplace#message(opts)[0]
     let error = get(res, 'error')
     if !empty(error)
       throw error


### PR DESCRIPTION
The method of passing through refactor-nrepl options does not work. Instead of attempting to configure via a stringified Clojure map to send to nrepl, allow the user to set options explicitly in a way that is more integrated into the vim ecosystem.

Only supports the `prune-ns-form` and `prefix-rewriting` so far.

This should address #3 